### PR TITLE
Remove old Docker check

### DIFF
--- a/lib/cide/builder.rb
+++ b/lib/cide/builder.rb
@@ -24,7 +24,6 @@ module CIDE
         create_tmp_file! TEMP_SSH_KEY, File.read(ssh_key)
       end
       create_tmp_file! DOCKERFILE, config.to_dockerfile
-      File.write("Dockerfile", config.to_dockerfile)
 
       build_options = ['--force-rm']
       build_options << '--pull' if pull

--- a/lib/cide/builder.rb
+++ b/lib/cide/builder.rb
@@ -24,6 +24,7 @@ module CIDE
         create_tmp_file! TEMP_SSH_KEY, File.read(ssh_key)
       end
       create_tmp_file! DOCKERFILE, config.to_dockerfile
+      File.write("Dockerfile", config.to_dockerfile)
 
       build_options = ['--force-rm']
       build_options << '--pull' if pull

--- a/lib/cide/cli.rb
+++ b/lib/cide/cli.rb
@@ -57,8 +57,6 @@ module CIDE
       default: '~/.ssh/id_rsa'
 
     def exec
-      setup_docker
-
       tag = name_to_tag options.name
 
       banner 'Config'
@@ -248,8 +246,6 @@ module CIDE
       desc: 'User to run under',
       default: 'cide'
     def debug
-      setup_docker
-
       tag = name_to_tag options.name
 
       ## Config ##
@@ -287,8 +283,6 @@ module CIDE
       default: 20,
       type: :numeric
     def clean
-      setup_docker
-
       days_to_keep = options[:days]
       max_images = options[:count]
 

--- a/lib/cide/docker.rb
+++ b/lib/cide/docker.rb
@@ -47,29 +47,5 @@ module CIDE
       exitstatus = $?.exitstatus
       raise Error, exitstatus if exitstatus > 0
     end
-
-    protected
-
-    def setup_docker
-      @setup_docker ||= (
-        # Check docker version
-        x = `docker version 2>/dev/null`
-        docker_version =
-          case x
-          when /Client version: ([^\s]+)/
-            $1
-          when /\s+Version:\s+([^\s]+)/
-            $1
-          else
-            raise VersionError, 'Unknown docker version'
-          end
-
-        if Gem::Version.new(docker_version) < Gem::Version.new('1.5.0')
-          raise VersionError, "Docker version #{$1} too old"
-        end
-
-        true
-      )
-    end
   end
 end


### PR DESCRIPTION
I was getting this error:

```
$ cide
/Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/2.0.0/rubygems/version.rb:191:in `initialize': Malformed version number string 17.12.0-ce (ArgumentError)
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/cide-0.9.1/lib/cide/docker.rb:57:in `new'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/cide-0.9.1/lib/cide/docker.rb:57:in `setup_docker'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/cide-0.9.1/lib/cide/cli.rb:60:in `exec'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /Users/jim/.rbenv/versions/2.0.0-p648/lib/ruby/gems/2.0.0/gems/cide-0.9.1/bin/cide:8:in `<top (required)>'
	from /Users/jim/.rbenv/versions/2.0.0/bin/cide:23:in `load'
	from /Users/jim/.rbenv/versions/2.0.0/bin/cide:23:in `<main>'
```

This is due to my Docker version `17.12.0-ce`:

```
$ docker version
Client:
 Version:	17.12.0-ce
 API version:	1.35
 Go version:	go1.9.2
 Git commit:	c97c6d6
 Built:	Wed Dec 27 20:03:51 2017
 OS/Arch:	darwin/amd64

Server:
 Engine:
  Version:	17.12.0-ce
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.9.2
  Git commit:	c97c6d6
  Built:	Wed Dec 27 20:12:29 2017
  OS/Arch:	linux/amd64
  Experimental:	false
```

`Gem::Version` doesn't understand this version string. Fair enough, since Docker is not a gem.

Fix: remove the check. I don't think this check is necessary. Docker 1.5 was over three years ago. It's enough to document the version requirement in the README, which we do.